### PR TITLE
[AP-629] Add more configurable consumer timing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,19 @@ or
 {
   "group_id": "1",
   "bootstrap_servers": "foo.com,bar.com",
+  "consumer_timeout_ms": 10000,
+  "session_timeout_ms": 30000,
+  "heartbeat_interval_ms": 10000,
+  "max_poll_interval_ms": 300000,
   "topic": "messages",
   "primary_keys": {
     "id": "$.jsonpath.to.primary_key"
   }
 }
 ```
+
+`consumer_timeout_ms` , `session_timeout_ms` , `heartbeat_interval_ms` and `max_poll_interval_ms` are optional
+parameters and set to the default values in the example above .
 
 This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD messages in the following format.
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='pipelinewise-tap-kafka',
           'Programming Language :: Python :: 3 :: Only'
       ],
       install_requires=[
-          'kafka-python',
+          'kafka-python==2.0.1',
           'pipelinewise-singer-python==1.*',
           'jsonpath_ng==1.4.3'
       ],

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -60,19 +60,27 @@ def get_args():
     return utils.parse_args(REQUIRED_CONFIG_KEYS)
 
 
+def generate_config(args_config):
+    return {
+        # Add required parameters
+        'topic': args_config['topic'],
+        'group_id': args_config['group_id'],
+        'bootstrap_servers': args_config['bootstrap_servers'].split(','),
+
+        # Add optional parameters with defaults
+        'consumer_timeout_ms': args_config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
+        'session_timeout_ms': args_config.get('session_timeout_ms', DEFAULT_SESSION_TIMEOUT_MS),
+        'heartbeat_interval_ms': args_config.get('heartbeat_interval_ms', DEFAULT_HEARTBEAT_INTERVAL_MS),
+        'max_poll_interval_ms': args_config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
+        'encoding': args_config.get('encoding', DEFAULT_ENCODING),
+        'primary_keys': args_config.get('primary_keys', {})
+    }
+
+
 def main_impl():
     """Main tap-kafka implementation"""
     args = get_args()
-    kafka_config = {'topic': args.config['topic'],
-                    'group_id': args.config['group_id'],
-                    'bootstrap_servers': args.config['bootstrap_servers'].split(','),
-                    'consumer_timeout_ms': args.config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
-                    'session_timeout_ms': args.config.get('session_timeout_ms', DEFAULT_SESSION_TIMEOUT_MS),
-                    'heartbeat_interval_ms': args.config.get('heartbeat_interval_m', DEFAULT_HEARTBEAT_INTERVAL_MS),
-                    'max_poll_interval_ms': args.config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
-                    'encoding': args.config.get('encoding', DEFAULT_ENCODING),
-                    'primary_keys': args.config.get('primary_keys', {})
-                    }
+    kafka_config = generate_config(args.config)
 
     if args.discover:
         do_discovery(args.config)

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -18,6 +18,12 @@ REQUIRED_CONFIG_KEYS = [
     # 'primary_keys'
 ]
 
+DEFAULT_CONSUMER_TIMEOUT_MS = 10000
+DEFAULT_SESSION_TIMEOUT_MS = 30000
+DEFAULT_HEARTBEAT_INTERVAL_MS = 10000
+DEFAULT_MAX_POLL_INTERVAL_MS = 300000
+DEFAULT_ENCODING = 'utf-8'
+
 
 def dump_catalog(all_streams):
     """Dump every stream catalog as JSON to STDOUT"""
@@ -31,7 +37,7 @@ def do_discovery(config):
         consumer = KafkaConsumer(config['topic'],
                                  group_id=config['group_id'],
                                  enable_auto_commit=False,
-                                 consumer_timeout_ms=config.get('consumer_timeout_ms', 10000),
+                                 consumer_timeout_ms=config['consumer_timeout_ms'],
                                  # value_deserializer=lambda m: json.loads(m.decode('ascii'))
                                  bootstrap_servers=config['bootstrap_servers'].split(','))
 
@@ -57,11 +63,14 @@ def get_args():
 def main_impl():
     """Main tap-kafka implementation"""
     args = get_args()
-
     kafka_config = {'topic': args.config['topic'],
                     'group_id': args.config['group_id'],
                     'bootstrap_servers': args.config['bootstrap_servers'].split(','),
-                    'encoding': args.config.get('encoding', 'utf-8'),
+                    'consumer_timeout_ms': args.config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
+                    'session_timeout_ms': args.config.get('session_timeout_ms', DEFAULT_SESSION_TIMEOUT_MS),
+                    'heartbeat_interval_ms': args.config.get('heartbeat_interval_m', DEFAULT_HEARTBEAT_INTERVAL_MS),
+                    'max_poll_interval_ms': args.config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
+                    'encoding': args.config.get('encoding', DEFAULT_ENCODING),
                     'primary_keys': args.config.get('primary_keys', {})
                     }
 

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -10,9 +10,9 @@ from singer import utils, metadata
 from kafka import KafkaConsumer, OffsetAndMetadata, TopicPartition
 from jsonpath_ng import parse
 
-
 LOGGER = singer.get_logger('tap_kafka')
-UPDATE_BOOKMARK_PERIOD = 10000
+LOG_MESSAGES_PERIOD = 1000
+UPDATE_BOOKMARK_PERIOD = 1000
 COMMIT_INTERVAL = 30
 
 
@@ -48,8 +48,9 @@ def commit_kafka_consumer(consumer, state, tap_stream_id):
     offset_to_commit = singer.get_bookmark(state, tap_stream_id, 'offset')
     partition_to_commit = singer.get_bookmark(state, tap_stream_id, 'partition')
 
-    if topic_to_commit and offset_to_commit and partition_to_commit:
+    if topic_to_commit and offset_to_commit is not None and partition_to_commit is not None:
         topic_partition = TopicPartition(topic_to_commit, partition_to_commit)
+        LOGGER.info("Committing consumed offset: %d", offset_to_commit + 1)
         consumer.commit({topic_partition: OffsetAndMetadata(offset_to_commit + 1, None)})
 
 
@@ -59,7 +60,10 @@ def do_sync(kafka_config, catalog, state, fn_get_args):
         kafka_config['topic'],
         group_id=kafka_config['group_id'],
         enable_auto_commit=False,
-        consumer_timeout_ms=kafka_config.get('consumer_timeout_ms', 10000),
+        consumer_timeout_ms=kafka_config['consumer_timeout_ms'],
+        session_timeout_ms=kafka_config['session_timeout_ms'],
+        heartbeat_interval_ms=kafka_config['heartbeat_interval_ms'],
+        max_poll_interval_ms=kafka_config['max_poll_interval_ms'],
         auto_offset_reset='earliest',
         value_deserializer=lambda m: json.loads(m.decode(kafka_config['encoding'])),
         bootstrap_servers=kafka_config['bootstrap_servers'])
@@ -73,9 +77,11 @@ def sync_stream(kafka_config, stream, state, consumer, fn_get_args):
     """Read kafka topic continuously and generate singer compatible messages to STDOUT"""
     send_schema_message(stream)
     stream_version = singer.get_bookmark(state, stream['tap_stream_id'], 'version')
-    topic = singer.get_bookmark(state, stream['tap_stream_id'], 'topic')
-    offset = singer.get_bookmark(state, stream['tap_stream_id'], 'offset')
-    partition = singer.get_bookmark(state, stream['tap_stream_id'], 'partition')
+    time_extracted = utils.now()
+    received_messages = 0
+    topic = None
+    offset = None
+    partition = None
     commit_timestamp = None
 
     if stream_version is None:
@@ -85,8 +91,6 @@ def sync_stream(kafka_config, stream, state, consumer, fn_get_args):
         stream=stream['tap_stream_id'],
         version=stream_version))
 
-    time_extracted = utils.now()
-    rows_saved = 0
     for message in consumer:
         LOGGER.debug("%s:%s:%s: key=%s value=%s" % (message.topic, message.partition,
                                                     message.offset, message.key,
@@ -97,6 +101,13 @@ def sync_stream(kafka_config, stream, state, consumer, fn_get_args):
             "message": message.value,
             "message_timestamp": message.timestamp
         }
+
+        # Log message stats periodically
+        received_messages += 1
+        if received_messages % LOG_MESSAGES_PERIOD == 0:
+            bookmark = state.get('bookmarks', {}).get(stream['tap_stream_id'])
+            LOGGER.info("%d messages received... Last received offset: %d Partition: %d -- Uncommitted bookmark: %s",
+                        received_messages, message.offset, message.partition, bookmark)
 
         # Add primary keys to the record message
         pks = kafka_config.get("primary_keys", [])
@@ -110,24 +121,23 @@ def sync_stream(kafka_config, stream, state, consumer, fn_get_args):
             stream=stream['tap_stream_id'],
             record=rec,
             time_extracted=time_extracted)
-        rows_saved += 1
 
         # Send record message
         singer.write_message(record)
 
         # Update offset and partition after every message but not committing yet
-        if not offset or message.offset > offset:
-            topic = message.topic
-            offset = message.offset
-            partition = message.partition
+        topic = message.topic
+        offset = message.offset
+        partition = message.partition
 
         # Every UPDATE_BOOKMARK_PERIOD, update the bookmark and send state message
-        if rows_saved % UPDATE_BOOKMARK_PERIOD == 0:
+        if received_messages % UPDATE_BOOKMARK_PERIOD == 0:
             state = update_bookmark(state,
                                     stream['tap_stream_id'],
                                     topic,
                                     offset,
                                     partition)
+            LOGGER.info("Updating bookmark and sending to tap consumer: %s", state)
             singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
         # Every COMMIT_INTERVAL, commit the latest offset from the state_file

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -6,12 +6,12 @@ from unittest.mock import patch
 
 from io import StringIO
 
+import tap_kafka
 from tap_kafka import common
 from tap_kafka import sync
 
 from tests.helper.parse_args_mock import ParseArgsMock
 from tests.helper.kafka_consumer_mock import KafkaConsumerMock
-
 
 
 def _get_resource_from_json(filename):
@@ -104,6 +104,54 @@ class TestSync(object):
     def setup_class(self):
         self.config = {
             "topic": "dummy_topic"
+        }
+
+    def test_generate_config_with_defaults(self):
+        """Should generate config dictionary with every required and optional parameter with defaults"""
+        minimal_config = {
+            'topic': 'my_topic',
+            'group_id': 'my_groupid',
+            'bootstrap_servers': 'server1,server2,server3'
+        }
+        assert tap_kafka.generate_config(minimal_config) == {
+            'topic': 'my_topic',
+            'group_id': 'my_groupid',
+            'bootstrap_servers': ['server1', 'server2','server3'],
+            'consumer_timeout_ms': tap_kafka.DEFAULT_CONSUMER_TIMEOUT_MS,
+            'session_timeout_ms': tap_kafka.DEFAULT_SESSION_TIMEOUT_MS,
+            'heartbeat_interval_ms': tap_kafka.DEFAULT_HEARTBEAT_INTERVAL_MS,
+            'max_poll_interval_ms': tap_kafka.DEFAULT_MAX_POLL_INTERVAL_MS,
+            'encoding': tap_kafka.DEFAULT_ENCODING,
+            'primary_keys': {}
+        }
+
+    def test_generate_config_with_custom_parameters(self):
+        """Should generate config dictionary with every required and optional parameter with custom values"""
+        minimal_config = {
+            'topic': 'my_topic',
+            'group_id': 'my_groupid',
+            'bootstrap_servers': 'server1,server2,server3',
+            'consumer_timeout_ms': 1111,
+            'session_timeout_ms': 2222,
+            'heartbeat_interval_ms': 3333,
+            'max_poll_interval_ms': 4444,
+            'encoding': 'iso-8859-1',
+            'primary_keys': {
+                'id': '$.jsonpath.to.primary_key'
+            }
+        }
+        assert tap_kafka.generate_config(minimal_config) == {
+            'topic': 'my_topic',
+            'group_id': 'my_groupid',
+            'bootstrap_servers': ['server1', 'server2','server3'],
+            'consumer_timeout_ms': 1111,
+            'session_timeout_ms': 2222,
+            'heartbeat_interval_ms': 3333,
+            'max_poll_interval_ms': 4444,
+            'encoding': 'iso-8859-1',
+            'primary_keys': {
+                'id': '$.jsonpath.to.primary_key'
+            }
         }
 
     def test_generate_schema_with_no_pk(self):


### PR DESCRIPTION
Currently we can configure only the `consumer_timeout_ms` parameter for kafka taps.

For better fine tuning of consuming messages and to avoid unexpected timeouts and to not stop consuming new messages we need to configure further kafka parameters. This PR makes the following kafka consumer parameters to be configurable:
* `session_timeout_ms`
* `heartbeat_interval_ms`
* `max_poll_intervali_ms`

Full list is available at https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html

This PR also adds some more verbose INFO level logging messages to understand better how this tap consuming messages from the topic.
