### PR TITLE
[AP-628] Add offset and partition to output singer message

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD
 
 | Property Name               | Description                                                                         |
 |-----------------------------|-------------------------------------------------------------------------------------|
+| MESSAGE_TIMESTAMP           | Timestamp extracted from the kafka metadata                                         |
+| MESSAGE_OFFSET              | Offset extracted from the kafka metadata                                            |
+| MESSAGE_PARTITION           | Partition extracted from the kafka metadata                                         |
 | MESSAGE                     | The original Kafka message                                                          |
 | DYNAMIC_PRIMARY_KEY(S)      | (Optional) Dynamically added primary key values, extracted from the Kafka message   |
 

--- a/tap_kafka/common.py
+++ b/tap_kafka/common.py
@@ -14,6 +14,8 @@ def generate_schema(primary_keys) -> object:
         "type": "object",
         "properties": {
             "message_timestamp": {"type": ["integer", "string", "null"]},
+            "message_offset": {"type": ["integer", "null"]},
+            "message_partition": {"type": ["integer", "null"]},
             "message": {"type": ["object", "array", "string", "null"]}
         }
     }

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -95,7 +95,9 @@ def sync_stream(kafka_config, stream, state, consumer, fn_get_args):
         # Create record message with columns
         rec = {
             "message": message.value,
-            "message_timestamp": message.timestamp
+            "message_timestamp": message.timestamp,
+            "message_offset": message.offset,
+            "message_partition": message.partition
         }
 
         # Add primary keys to the record message

--- a/tests/resources/catalog.json
+++ b/tests/resources/catalog.json
@@ -25,6 +25,18 @@
                "null"
             ]
          },
+         "message_offset":{
+            "type":[
+               "integer",
+               "null"
+            ]
+         },
+         "message_partition":{
+            "type":[
+               "integer",
+               "null"
+            ]
+         },
          "message":{
             "type":[
                "object",

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -22,7 +22,9 @@ def _get_resource_from_json(filename):
 def _message_to_singer_record(message):
     return {
         'message': message.get('value'),
-        'message_timestamp': message.get('timestamp')
+        'message_timestamp': message.get('timestamp'),
+        'message_offset': message.get('offset'),
+        'message_partition': message.get('partition')
     }
 
 
@@ -113,6 +115,8 @@ class TestSync(object):
                 "type": "object",
                 "properties": {
                     "message_timestamp": {"type": ["integer", "string", "null"]},
+                    "message_offset": {"type": ["integer", "null"]},
+                    "message_partition": {"type": ["integer", "null"]},
                     "message": {"type": ["object", "array", "string", "null"]}
                 }
             }
@@ -125,6 +129,8 @@ class TestSync(object):
                 "properties": {
                     "id": {"type": ["string", "null"]},
                     "message_timestamp": {"type": ["integer", "string", "null"]},
+                    "message_offset": {"type": ["integer", "null"]},
+                    "message_partition": {"type": ["integer", "null"]},
                     "message": {"type": ["object", "array", "string", "null"]}
                 }
             }
@@ -138,6 +144,8 @@ class TestSync(object):
                     "id": {"type": ["string", "null"]},
                     "version": {"type": ["string", "null"]},
                     "message_timestamp": {"type": ["integer", "string", "null"]},
+                    "message_offset": {"type": ["integer", "null"]},
+                    "message_partition": {"type": ["integer", "null"]},
                     "message": {"type": ["object", "array", "string", "null"]}
                 }
             }
@@ -157,6 +165,8 @@ class TestSync(object):
                            "type": "object",
                            "properties": {
                                 "message_timestamp": {"type": ["integer", "string", "null"]},
+                                "message_offset": {"type": ["integer", "null"]},
+                                "message_partition": {"type": ["integer", "null"]},
                                 "message": {"type": ["object", "array", "string", "null"]}
                            }
                        },
@@ -180,6 +190,8 @@ class TestSync(object):
                            "properties": {
                                 "id": {"type": ["string", "null"]},
                                 "message_timestamp": {"type": ["integer", "string", "null"]},
+                                "message_offset": {"type": ["integer", "null"]},
+                                "message_partition": {"type": ["integer", "null"]},
                                 "message": {"type": ["object", "array", "string", "null"]}
                            }
                        },
@@ -204,6 +216,8 @@ class TestSync(object):
                                 "id": {"type": ["string", "null"]},
                                 "version": {"type": ["string", "null"]},
                                 "message_timestamp": {"type": ["integer", "string", "null"]},
+                                "message_offset": {"type": ["integer", "null"]},
+                                "message_partition": {"type": ["integer", "null"]},
                                 "message": {"type": ["object", "array", "string", "null"]}
                            }
                        },


### PR DESCRIPTION
This PR adds `MESSAGE_OFFSET` and `MESSAGE_PARTITION` columns to the output singer messages. This is useful for debugging when we want to know not only the timestamp of the messages but the exact locations in the kafka topic.
