### PR TITLE
[AP-630] Add local storage and instant commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *__pycache__/
 *~
 dist/
+test_dir/
 
 # Singer JSON files
 properties.json

--- a/README.md
+++ b/README.md
@@ -42,21 +42,32 @@ or
 
 ```
 {
-  "group_id": "1",
   "bootstrap_servers": "foo.com,bar.com",
-  "consumer_timeout_ms": 10000,
-  "session_timeout_ms": 30000,
-  "heartbeat_interval_ms": 10000,
-  "max_poll_interval_ms": 300000,
-  "topic": "messages",
+  "group_id": "my_group",
+  "topic": "my_topic",
   "primary_keys": {
     "id": "$.jsonpath.to.primary_key"
   }
 }
 ```
 
-`consumer_timeout_ms` , `session_timeout_ms` , `heartbeat_interval_ms` and `max_poll_interval_ms` are optional
-parameters and set to the default values in the example above .
+Full list of options in `config.json`:
+
+| Property                            | Type    | Required?  | Description                                                   |
+|-------------------------------------|---------|------------|---------------------------------------------------------------|
+| bootstrap_servers                   | String  | Yes        | `host[:port]` string (or list of comma separated `host[:port]` strings) that the consumer should contact to bootstrap initial cluster metadata. |
+| group_id                            | String  | Yes        | The name of the consumer group to join for dynamic partition assignment (if enabled), and to use for fetching and committing offsets. |
+| topic                               | String  | Yes        | Name of kafka topics to subscribe to |
+| primary_keys                        | Object  |            | Optionally you can define primary key for the consumed messages. It requires a column name and JSONPath selector to extract the value from the kafka messages. The extracted column will be added to every output singer message. |
+| max_runtime_ms                      | Integer |            | (Default: 300000) The maximum time for the tap to collect new messages from Kafka topic. If this time exceeds it will flush the batch and close kafka connection. |
+| batch_size_rows                     | Integer |            | (Default: 1000) Consumed kafka messages are transformed to batches and batches written to STDOUT in singer message format *only* when the batch is full. Set this value low to have more realtime experience. |
+| batch_flush_interval_ms             | Integer |            | (Default: 60000) The maximum delay between flushing batches. Exceeding this time will force flushing singer messages to STDOUT even if the batch is not full. |
+| consumer_timeout_ms                 | Integer |            | (Default: 10000) KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration            |
+| session_timeout_ms                  | Integer |            | (Default: 30000) KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities. |                                      |
+| heartbeat_interval_ms               | Integer |            | (Default: 10000) KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities. |
+| max_poll_interval_ms                | Integer |            | (Default: 300000) KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management. |
+| local_store_dir                     | String  |            | (Default: current working dir) tap-kafka maintains an intermediate file based local storage. Every consumed message first added into this store and periodically flushing the content to STDOUT for other singer components. This mechanism allows to send commit messages quickly to Kafka brokers and avoid unexpected re-balancing caused by long running message consumptions. |
+
 
 This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD messages in the following format.
 
@@ -72,7 +83,7 @@ This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD
 ### Run the tap in Discovery Mode
 
 ```
-tap-kafka --config config.json --discover                # Should dump a Catalog to sdtout
+tap-kafka --config config.json --discover                # Should dump a Catalog to stdout
 tap-kafka --config config.json --discover > catalog.json # Capture the Catalog
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(name='pipelinewise-tap-kafka',
       install_requires=[
           'kafka-python==2.0.1',
           'pipelinewise-singer-python==1.*',
-          'jsonpath_ng==1.4.3'
+          'jsonpath_ng==1.4.3',
+          'filelock==3.0.12'
       ],
       extras_require={
           "test": [

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -1,4 +1,5 @@
 """pipelinewise-tap-kafka"""
+import os
 import sys
 import json
 
@@ -12,17 +13,21 @@ import tap_kafka.common as common
 LOGGER = singer.get_logger('tap_kafka')
 
 REQUIRED_CONFIG_KEYS = [
-    'group_id',
     'bootstrap_servers',
+    'group_id',
     'topic'
-    # 'primary_keys'
 ]
 
+
+DEFAULT_MAX_RUNTIME_MS = 300000
+DEFAULT_BATCH_SIZE_ROWS = 1000
+DEFAULT_BATCH_FLUSH_INTERVAL_MS = 60000
 DEFAULT_CONSUMER_TIMEOUT_MS = 10000
 DEFAULT_SESSION_TIMEOUT_MS = 30000
 DEFAULT_HEARTBEAT_INTERVAL_MS = 10000
 DEFAULT_MAX_POLL_INTERVAL_MS = 300000
 DEFAULT_ENCODING = 'utf-8'
+DEFAULT_LOCAL_STORE_DIR = os.path.join(os.getcwd(), 'tap-kafka-local-store')
 
 
 def dump_catalog(all_streams):
@@ -68,12 +73,16 @@ def generate_config(args_config):
         'bootstrap_servers': args_config['bootstrap_servers'].split(','),
 
         # Add optional parameters with defaults
+        'primary_keys': args_config.get('primary_keys', {}),
+        'max_runtime_ms': args_config.get('max_runtime_ms', DEFAULT_MAX_RUNTIME_MS),
+        'batch_size_rows': args_config.get('batch_size_rows', DEFAULT_BATCH_SIZE_ROWS),
+        'batch_flush_interval_ms': args_config.get('batch_flush_interval_ms', DEFAULT_BATCH_FLUSH_INTERVAL_MS),
         'consumer_timeout_ms': args_config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
         'session_timeout_ms': args_config.get('session_timeout_ms', DEFAULT_SESSION_TIMEOUT_MS),
         'heartbeat_interval_ms': args_config.get('heartbeat_interval_ms', DEFAULT_HEARTBEAT_INTERVAL_MS),
         'max_poll_interval_ms': args_config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
         'encoding': args_config.get('encoding', DEFAULT_ENCODING),
-        'primary_keys': args_config.get('primary_keys', {})
+        'local_store_dir': args_config.get('local_store_dir', DEFAULT_LOCAL_STORE_DIR)
     }
 
 
@@ -86,7 +95,6 @@ def main_impl():
         do_discovery(args.config)
     elif args.properties:
         state = args.state or {}
-        # streams = args.properties or {'streams' : common.default_streams(kafka_config)}
         sync.do_sync(kafka_config, args.properties, state, fn_get_args=get_args)
     else:
         LOGGER.info("No properties were selected")

--- a/tap_kafka/local_store.py
+++ b/tap_kafka/local_store.py
@@ -1,0 +1,167 @@
+"""Internal store to keep consumed messages from Kafka on disk to keep short commit periods"""
+import os
+import sys
+import time
+import singer
+import logging
+import filelock
+from filelock import FileLock
+
+# Set filelock logging less werbose
+filelock.logger().setLevel(logging.WARNING)
+
+
+class LocalStore:
+    # pylint: disable=too-many-arguments
+    def __init__(self, directory, topic, prefix='tap-kafka-local-store-', postfix='', extension='db'):
+        """Initialize local storage
+
+        :param directory: directory path
+        :param topic: name of the local store
+        :param prefix: Optional file name prefix
+        :param postfix: Optional file name postfix
+        :param extension: Optional file name extension
+        """
+        self.directory = os.path.expanduser(directory)
+        self.topic = topic
+        self.name = f'{prefix}{topic}{postfix}.{extension}'
+        self.path = os.path.join(directory, self.name)
+        self.temp = f'{self.path}.temp'
+        self.lock = f'{self.path}.lock'
+
+        # Create the directory if not exists
+        if not os.path.exists(directory):
+            os.makedirs(directory, exist_ok=True)
+
+        # Create an empty file if not exists
+        if not os.path.exists(self.path):
+            open(self.path, 'w')
+
+    @staticmethod
+    def _blocks(file, size=65536):
+        """Reads a file by block chunks"""
+        while True:
+            b = file.read(size)
+            if not b:
+                break
+            yield b
+
+    @staticmethod
+    def _split_line(line: str) -> list:
+        """Every message in the file is timestamped in the following format:
+          1585817817.5626152:{"type":"RECORD","value":{"col_1":"value_1"}}
+
+        This method split the original message to timestamp and the real message
+        componets and returns as list of two items.
+        """
+        return line.split(':', 1)
+
+    @staticmethod
+    def _flush(message: str):
+        """Flush anything to stdout"""
+        sys.stdout.write(message)
+        sys.stdout.flush()
+
+    def _flush_line(self, line: str):
+        """Takes a line from the local store and sends *only* the message part to stdout.
+
+         Every item in the file is timestamped in the following format:
+          1585817817.5626152:{"type":"RECORD","value":{"col_1":"value_1"}}
+
+        This function is removing the timestamp part"""
+        message = self._split_line(line)[1]
+        self._flush(message)
+
+    def count_all(self) -> int:
+        """Returns the number of messages in the store
+
+        This functions reads the entire file with low memory footprint
+        and counts the number of newline characters"""
+        with FileLock(self.lock):
+            try:
+                with open(self.path, 'r') as msf:
+                    return sum(block.count('\n') for block in self._blocks(msf))
+
+            # Return 0 if no local store file
+            except FileNotFoundError:
+                return 0
+
+    def purge(self):
+        """Delete every message from the store"""
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+        if os.path.exists(self.lock):
+            os.remove(self.lock)
+
+    def insert(self, message: str) -> float:
+        """Insert a new message with a generated timestamp
+        Returns the insert timestamp"""
+        with FileLock(self.lock):
+            with open(self.path, 'a+') as msf:
+                insert_ts = time.time()
+                msf.write(f'{insert_ts}:{message}' + '\n')
+        return insert_ts
+
+    def delete_before(self, timestamp: float) -> float:
+        """Delete messages before a certain timestamp
+
+        This function creates a temporary file *only* with lines required to keep.
+        Once every required line copied, it swaps the files.
+
+        Returns the timestamp of last delete message"""
+        last_timestamp = timestamp
+        with FileLock(self.lock):
+            with open(self.path, 'r') as msf:
+                with open(self.temp, 'w') as msf_temp:
+                    for line in msf:
+                        msg_timestamp, message = self._split_line(line)
+                        if float(msg_timestamp) > timestamp:
+                            msf_temp.write(line)
+                        else:
+                            last_timestamp = msg_timestamp
+
+        # Rename the temp file to be the new active
+        if os.path.exists(self.temp):
+            os.rename(self.temp, self.path)
+
+        return last_timestamp
+
+    def delete_before_bookmark(self, state: dict) -> int:
+        """Delete message before bookmarked timestamp in state
+
+        Returns the timestamp of last delete message"""
+        timestamp = singer.get_bookmark(state, self.topic, 'timestamp')
+        if timestamp is not None:
+            return self.delete_before(timestamp)
+        return 0
+
+    def flush_after(self, timestamp: float) -> float:
+        """Flush every message after a certain timestamp to stdout
+
+        Returns the timestamp of last flushed message"""
+        pos = timestamp
+        with FileLock(self.lock):
+            with open(self.path, 'r') as msf:
+                for line in msf:
+                    msg_timestamp, message = self._split_line(line)
+                    if float(msg_timestamp) >= timestamp:
+                        self._flush(message)
+                        pos = msg_timestamp
+        return pos
+
+    def flush_after_bookmark(self, state: dict) -> float:
+        """Flush every message after a singer bookmark
+
+        Returns the timestamp of last flushed message"""
+        timestamp = singer.get_bookmark(state, self.topic, 'timestamp')
+        if timestamp is not None:
+            return self.flush_after(timestamp)
+        return 0
+
+    def flush_all(self):
+        """Flush every message to stdout"""
+        with FileLock(self.lock):
+            with open(self.path, 'r') as msf:
+                for line in msf:
+                    self._flush_line(line)

--- a/tests/helper/local_store_mock.py
+++ b/tests/helper/local_store_mock.py
@@ -1,0 +1,12 @@
+class LocalStoreMock:
+    """
+    Mocked singer args class
+    """
+    def __init__(self, state={}):
+        self.state = state
+        self.messages = []
+
+    def insert(self, message: str) -> float:
+        self.messages.append(message)
+        insert_ts = 123456
+        return insert_ts

--- a/tests/resources/state-with-bookmark.json
+++ b/tests/resources/state-with-bookmark.json
@@ -1,1 +1,1 @@
-{"bookmarks":  {"dummy_topic": {"topic": "dummy_topic", "offset": 3, "partition": 2}}}
+{"bookmarks":  {"dummy_topic": {"timestamp": 123456}}}

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,0 +1,102 @@
+import os
+import time
+
+from tap_kafka.local_store import LocalStore
+
+
+class TestLocalStore:
+    """
+    Unit Tests
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.test_dir = './test_dir'
+
+    def test_properties(self):
+        """Validate if default class variables defined correctly"""
+        local_store = LocalStore(self.test_dir, 'my_stream_name')
+        assert local_store.directory == self.test_dir
+        assert local_store.name == 'tap-kafka-local-store-my_stream_name.db'
+        assert local_store.path == os.path.join(local_store.directory, local_store.name)
+
+    def test_properties_with_custom_args(self):
+        """Validate if customised class variables defined correctly"""
+        local_store = LocalStore(self.test_dir, 'my_stream_name', prefix='prefix-', postfix='-postfix', extension='txt')
+        assert local_store.directory == self.test_dir
+        assert local_store.name == 'prefix-my_stream_name-postfix.txt'
+        assert local_store.path == os.path.join(local_store.directory, local_store.name)
+
+    def test_add_and_get_and_write_messages(self, capsys):
+        """Validate if adding, reading and writing message to stdout work as expected"""
+        local_store = LocalStore(self.test_dir, 'my_stream_name')
+        local_store.purge()
+
+        # Add one single message
+        time_of_first_insert = time.time()
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_1"}}')
+        assert local_store.count_all() == 1
+
+        # Add couple of more messages
+        time_of_second_insert = time.time()
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_2"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_3"}}')
+        assert local_store.count_all() == 3
+
+        # Flush everything after the first insert
+        local_store.flush_after(time_of_first_insert)
+        stdout, stderr = capsys.readouterr()
+        assert stdout == """{"type":"RECORD","value":{"col_1":"value_1"}}
+{"type":"RECORD","value":{"col_1":"value_2"}}
+{"type":"RECORD","value":{"col_1":"value_3"}}
+"""
+
+        # Flush everything after the second insert
+        local_store.flush_after(time_of_second_insert)
+        stdout, stderr = capsys.readouterr()
+        assert stdout == """{"type":"RECORD","value":{"col_1":"value_2"}}
+{"type":"RECORD","value":{"col_1":"value_3"}}
+"""
+
+        # Flush everything to stdout
+        local_store.flush_all()
+        stdout, stderr = capsys.readouterr()
+        assert stdout == """{"type":"RECORD","value":{"col_1":"value_1"}}
+{"type":"RECORD","value":{"col_1":"value_2"}}
+{"type":"RECORD","value":{"col_1":"value_3"}}
+"""
+
+        # Delete some old items
+        local_store.delete_before(time_of_second_insert)
+
+        # Flush everything again, first inserted line should not be there
+        local_store.flush_all()
+        stdout, stderr = capsys.readouterr()
+        assert stdout == """{"type":"RECORD","value":{"col_1":"value_2"}}
+{"type":"RECORD","value":{"col_1":"value_3"}}
+"""
+
+        # Clear and test if it's empty
+        local_store.purge()
+        assert local_store.count_all() == 0
+
+    def test_message_counter(self):
+        """Validate if adding, reading and writing message to stdout work as expected"""
+        local_store = LocalStore(self.test_dir, 'my_stream_name')
+        local_store.purge()
+
+        # Add some lines
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_1"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_2"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_3"}}')
+        assert local_store.count_all() == 3
+
+        # Add some more lines
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_4"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_5"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_6"}}')
+        assert local_store.count_all() == 6
+
+        # Clear and test if it's empty
+        local_store.purge()
+        assert local_store.count_all() == 0


### PR DESCRIPTION
**Summary**
This PR adds a file based local storage to allow instant commits to Kafka. Currently we commit only once at the beginning from the state file to avoid committing not fully processed messages by the target component. Unfortunately this logic is causing lot of re-balancing events when reading the topic, that triggers re-processing lot of already consumed messages and results heavily lagging data.

This PR changing this behaviour and the consumed messages from kafka saved into a local disk storage  quickly so it doesn't need to wait feedback from target component. A batching mechanism keeps maintaining flushing and deleting messages from the local storage.

The position in the state file is **not** the message position in the kafka topic but the position in the local storage. 

**New columns**
Two new columns added automatically to every singer record to tell the exact location of the message in the kafka topic:
`MESSAGE_OFFSET`: Offset extracted from the kafka metadata
`MESSAGE_PARTITION`: Partition extracted from the kafka metadata

**New configurable Parameters**
`max_runtime_ms`: (Default: 300000) The maximum time for the tap to collect new messages from Kafka topic.
`batch_size_rows`: (Default: 1000) Size of batch with consumed kafka messages to flush to STDOUT
`batch_flush_interval_ms`: (Default: 60000) The maximum delay between flushing batches. Exceeding this time will force flushing batch.
`local_store_dir`: (Default: current working dir) Location of the intermediate file based local storage.
