### PR TITLE
[AP-657] Add max_poll_records option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Full list of options in `config.json`:
 | consumer_timeout_ms                 | Integer |            | (Default: 10000) KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration            |
 | session_timeout_ms                  | Integer |            | (Default: 30000) KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities. |                                      |
 | heartbeat_interval_ms               | Integer |            | (Default: 10000) KafkaConsumer setting. The expected time in milliseconds between heartbeats to the consumer coordinator when using Kafka’s group management facilities. |
+| max_poll_records                    | Integer |            | (Default: 500) KafkaConsumer setting. The maximum number of records returned in a single call to poll(). |
 | max_poll_interval_ms                | Integer |            | (Default: 300000) KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management. |
 | local_store_dir                     | String  |            | (Default: current working dir) tap-kafka maintains an intermediate file based local storage. Every consumed message first added into this store and periodically flushing the content to STDOUT for other singer components. This mechanism allows to send commit messages quickly to Kafka brokers and avoid unexpected re-balancing caused by long running message consumptions. |
 

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -26,6 +26,7 @@ DEFAULT_CONSUMER_TIMEOUT_MS = 10000
 DEFAULT_SESSION_TIMEOUT_MS = 30000
 DEFAULT_HEARTBEAT_INTERVAL_MS = 10000
 DEFAULT_MAX_POLL_INTERVAL_MS = 300000
+DEFAULT_MAX_POLL_RECORDS = 500
 DEFAULT_ENCODING = 'utf-8'
 DEFAULT_LOCAL_STORE_DIR = os.path.join(os.getcwd(), 'tap-kafka-local-store')
 
@@ -80,6 +81,7 @@ def generate_config(args_config):
         'consumer_timeout_ms': args_config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
         'session_timeout_ms': args_config.get('session_timeout_ms', DEFAULT_SESSION_TIMEOUT_MS),
         'heartbeat_interval_ms': args_config.get('heartbeat_interval_ms', DEFAULT_HEARTBEAT_INTERVAL_MS),
+        'max_poll_records': args_config.get('max_poll_records', DEFAULT_MAX_POLL_RECORDS),
         'max_poll_interval_ms': args_config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
         'encoding': args_config.get('encoding', DEFAULT_ENCODING),
         'local_store_dir': args_config.get('local_store_dir', DEFAULT_LOCAL_STORE_DIR)

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -71,6 +71,7 @@ def init_kafka_consumer(kafka_config):
         consumer_timeout_ms=kafka_config['consumer_timeout_ms'],
         session_timeout_ms=kafka_config['session_timeout_ms'],
         heartbeat_interval_ms=kafka_config['heartbeat_interval_ms'],
+        max_poll_records=kafka_config['max_poll_records'],
         max_poll_interval_ms=kafka_config['max_poll_interval_ms'],
 
         # Non-configurable parameters

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -128,6 +128,7 @@ class TestSync(object):
             'consumer_timeout_ms': tap_kafka.DEFAULT_CONSUMER_TIMEOUT_MS,
             'session_timeout_ms': tap_kafka.DEFAULT_SESSION_TIMEOUT_MS,
             'heartbeat_interval_ms': tap_kafka.DEFAULT_HEARTBEAT_INTERVAL_MS,
+            'max_poll_records': tap_kafka.DEFAULT_MAX_POLL_RECORDS,
             'max_poll_interval_ms': tap_kafka.DEFAULT_MAX_POLL_INTERVAL_MS,
             'encoding': tap_kafka.DEFAULT_ENCODING,
             'local_store_dir': tap_kafka.DEFAULT_LOCAL_STORE_DIR
@@ -148,7 +149,8 @@ class TestSync(object):
             'consumer_timeout_ms': 1111,
             'session_timeout_ms': 2222,
             'heartbeat_interval_ms': 3333,
-            'max_poll_interval_ms': 4444,
+            'max_poll_records': 4444,
+            'max_poll_interval_ms': 5555,
             'encoding': 'iso-8859-1',
             'local_store_dir': '/tmp/local-store'
         }
@@ -165,7 +167,8 @@ class TestSync(object):
             'consumer_timeout_ms': 1111,
             'session_timeout_ms': 2222,
             'heartbeat_interval_ms': 3333,
-            'max_poll_interval_ms': 4444,
+            'max_poll_records': 4444,
+            'max_poll_interval_ms': 5555,
             'encoding': 'iso-8859-1',
             'local_store_dir': '/tmp/local-store'
         }


### PR DESCRIPTION
Add `max_poll_records` kafka consumer option to `config.json`.


`max_poll_records`: (Default: 500) KafkaConsumer setting. The maximum number of records returned in a single call to poll().


[All KafkaConsumer options docs](https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafkaconsumer)