### PR TITLE
[AP-786] Write local store in batches and commit periodically to avoid high I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Full list of options in `config.json`:
 | primary_keys                        | Object  |            | Optionally you can define primary key for the consumed messages. It requires a column name and JSONPath selector to extract the value from the kafka messages. The extracted column will be added to every output singer message. |
 | max_runtime_ms                      | Integer |            | (Default: 300000) The maximum time for the tap to collect new messages from Kafka topic. If this time exceeds it will flush the batch and close kafka connection. |
 | batch_size_rows                     | Integer |            | (Default: 1000) Consumed kafka messages are transformed to batches and batches written to STDOUT in singer message format *only* when the batch is full. Set this value low to have more realtime experience. |
+| commit_interval_ms                  | Integer |            | (Default: 5000) Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store. |
 | batch_flush_interval_ms             | Integer |            | (Default: 60000) The maximum delay between flushing batches. Exceeding this time will force flushing singer messages to STDOUT even if the batch is not full. |
 | consumer_timeout_ms                 | Integer |            | (Default: 10000) KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration            |
 | session_timeout_ms                  | Integer |            | (Default: 30000) KafkaConsumer setting. The timeout used to detect failures when using Kafka’s group management facilities. |                                      |
@@ -68,7 +69,7 @@ Full list of options in `config.json`:
 | max_poll_records                    | Integer |            | (Default: 500) KafkaConsumer setting. The maximum number of records returned in a single call to poll(). |
 | max_poll_interval_ms                | Integer |            | (Default: 300000) KafkaConsumer setting. The maximum delay between invocations of poll() when using consumer group management. |
 | local_store_dir                     | String  |            | (Default: current working dir) tap-kafka maintains an intermediate file based local storage. Every consumed message first added into this store and periodically flushing the content to STDOUT for other singer components. This mechanism allows to send commit messages quickly to Kafka brokers and avoid unexpected re-balancing caused by long running message consumptions. |
-
+| local_store_batch_size_rows         | Integer |            | (Default: 1000) Number of messages to write to disk in one go. This can avoid high I/O issues when messages written to local store disk too frequently. |
 
 This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD messages in the following format.
 

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -20,6 +20,7 @@ REQUIRED_CONFIG_KEYS = [
 
 
 DEFAULT_MAX_RUNTIME_MS = 300000
+DEFAULT_COMMIT_INTERVAL_MS = 5000
 DEFAULT_BATCH_SIZE_ROWS = 1000
 DEFAULT_BATCH_FLUSH_INTERVAL_MS = 60000
 DEFAULT_CONSUMER_TIMEOUT_MS = 10000
@@ -29,6 +30,7 @@ DEFAULT_MAX_POLL_INTERVAL_MS = 300000
 DEFAULT_MAX_POLL_RECORDS = 500
 DEFAULT_ENCODING = 'utf-8'
 DEFAULT_LOCAL_STORE_DIR = os.path.join(os.getcwd(), 'tap-kafka-local-store')
+DEFAULT_LOCAL_STORE_BATCH_SIZE_ROWS = 1000
 
 
 def dump_catalog(all_streams):
@@ -76,6 +78,7 @@ def generate_config(args_config):
         # Add optional parameters with defaults
         'primary_keys': args_config.get('primary_keys', {}),
         'max_runtime_ms': args_config.get('max_runtime_ms', DEFAULT_MAX_RUNTIME_MS),
+        'commit_interval_ms': args_config.get('commit_interval_ms', DEFAULT_COMMIT_INTERVAL_MS),
         'batch_size_rows': args_config.get('batch_size_rows', DEFAULT_BATCH_SIZE_ROWS),
         'batch_flush_interval_ms': args_config.get('batch_flush_interval_ms', DEFAULT_BATCH_FLUSH_INTERVAL_MS),
         'consumer_timeout_ms': args_config.get('consumer_timeout_ms', DEFAULT_CONSUMER_TIMEOUT_MS),
@@ -84,7 +87,9 @@ def generate_config(args_config):
         'max_poll_records': args_config.get('max_poll_records', DEFAULT_MAX_POLL_RECORDS),
         'max_poll_interval_ms': args_config.get('max_poll_interval_ms', DEFAULT_MAX_POLL_INTERVAL_MS),
         'encoding': args_config.get('encoding', DEFAULT_ENCODING),
-        'local_store_dir': args_config.get('local_store_dir', DEFAULT_LOCAL_STORE_DIR)
+        'local_store_dir': args_config.get('local_store_dir', DEFAULT_LOCAL_STORE_DIR),
+        'local_store_batch_size_rows': args_config.get('local_store_batch_size_rows',
+                                                       DEFAULT_LOCAL_STORE_BATCH_SIZE_ROWS)
     }
 
 

--- a/tests/helper/local_store_mock.py
+++ b/tests/helper/local_store_mock.py
@@ -4,9 +4,21 @@ class LocalStoreMock:
     """
     def __init__(self, state={}):
         self.state = state
+        self.messages_to_persist = []
         self.messages = []
+        self.last_inserted_ts = 123456
+        self.last_persisted_ts = 123456
+
+    def persist_messages(self) -> float:
+        for message in self.messages_to_persist:
+            self.messages.append(message)
+
+        self.messages_to_persist = []
+        persist_ts = 123456
+        return persist_ts
 
     def insert(self, message: str) -> float:
-        self.messages.append(message)
+        self.messages_to_persist.append(message)
+
         insert_ts = 123456
         return insert_ts

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -100,3 +100,23 @@ class TestLocalStore:
         # Clear and test if it's empty
         local_store.purge()
         assert local_store.count_all() == 0
+
+    def test_insert_with_custom_batch(self):
+        """Validate if using custom batch size rows works as expected"""
+        local_store = LocalStore(self.test_dir, 'my_stream_name', batch_size_rows=5)
+        local_store.purge()
+
+        # Inserting 12 lines, should be persisted in multiple batches
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_1"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_2"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_3"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_4"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_5"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_6"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_7"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_8"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_9"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_10"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_11"}}')
+        local_store.insert('{"type":"RECORD","value":{"col_1":"value_12"}}')
+        assert local_store.count_all() == 12


### PR DESCRIPTION
## Problem

Tap kafka currently appending new messages to file in the local store on disk after every single message. This is causing high I/O issues if the underlying disk  cannot write files fast enough. (Like EFS)

## Proposed changes

When data received from kafka, we keep the messages in memory. Messages in memory written to disk in local store after certain number of messages received: `local_store_batch_size_rows `: default 1000 messages.

Messages from kafka processed in two stages:
1. **Consumed**: data received from kafka but messages stays in memory. Sending commit message from a consumed message is not safe.
2. **Persisted**: data written to local store on disk when `local_store_batch_size_rows` number of messages received. Sending commit message from persisted message is safe .

Commit messages sent periodically to kafka and it's configurable by the `commit_interval_ms` parameter and it defaults to 5 seconds. The commit message is the partition and offset of the last **persisted** message.   





