### PR TITLE
[AP-826] Convert timestamp in bookmark to float

### DIFF
--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -1,4 +1,4 @@
-class InvalidStateFileException(Exception):
+class InvalidBookmarkException(Exception):
     """
     Exception to raise when state file is not valid
     """

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -1,0 +1,6 @@
+class InvalidStateFileException(Exception):
+    """
+    Exception to raise when state file is not valid
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -1,6 +1,6 @@
 class InvalidBookmarkException(Exception):
     """
-    Exception to raise when state file is not valid
+    Exception to raise when bookmark is not valid
     """
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)

--- a/tap_kafka/local_store.py
+++ b/tap_kafka/local_store.py
@@ -7,16 +7,10 @@ import logging
 import filelock
 from filelock import FileLock
 
+from .errors import InvalidStateFileException
+
 # Set filelock logging less werbose
 filelock.logger().setLevel(logging.WARNING)
-
-
-class InvalidStateFileException(Exception):
-    """
-    Exception to raise when state file is not valid
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(self, *args, **kwargs)
 
 
 class LocalStore:

--- a/tap_kafka/local_store.py
+++ b/tap_kafka/local_store.py
@@ -7,7 +7,7 @@ import logging
 import filelock
 from filelock import FileLock
 
-from .errors import InvalidStateFileException
+from .errors import InvalidBookmarkException
 
 # Set filelock logging less werbose
 filelock.logger().setLevel(logging.WARNING)
@@ -69,11 +69,11 @@ class LocalStore:
         """Get the timestamp for a specific topic from the state dict
 
         Returns timestamp as float and do automatic type conversion if possible,
-        otherwise throws InvalidStateFileException"""
+        otherwise throws InvalidBookmarkException"""
         try:
             timestamp = float(singer.get_bookmark(state, topic, 'timestamp'))
         except ValueError:
-            raise InvalidStateFileException(f'The timestamp in the state file for {topic} stream is not numeric')
+            raise InvalidBookmarkException(f'The timestamp in the bookmark for {topic} stream is not numeric')
 
         return timestamp
 

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -9,7 +9,7 @@ from tap_kafka.local_store import LocalStore
 from kafka import KafkaConsumer, OffsetAndMetadata, TopicPartition
 from jsonpath_ng import parse
 
-from .errors import InvalidStateFileException
+from .errors import InvalidBookmarkException
 
 LOGGER = singer.get_logger('tap_kafka')
 
@@ -54,7 +54,7 @@ def update_bookmark(state, topic, timestamp):
     try:
         timestamp = float(timestamp) if timestamp else 0
     except ValueError:
-        raise InvalidStateFileException(f'The timestamp in the state file for {topic} stream is not numeric')
+        raise InvalidBookmarkException(f'The timestamp in the bookmark for {topic} stream is not numeric')
 
     return singer.write_bookmark(state, topic, 'timestamp', timestamp)
 

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 from tap_kafka.local_store import LocalStore
-from tap_kafka.errors import InvalidStateFileException
+from tap_kafka.errors import InvalidBookmarkException
 
 
 class TestLocalStore:
@@ -154,5 +154,5 @@ class TestLocalStore:
         assert ts == 1598434967.5782337
 
         # Timestamp that cannot be converted to float should raise exception
-        with pytest.raises(InvalidStateFileException):
+        with pytest.raises(InvalidBookmarkException):
             local_store._get_timestamp_from_state(state, 'stream_ts_as_invalid_string')

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -133,10 +133,10 @@ class TestLocalStore:
                     'timestamp': 1598434967.5782337
                 },
                 'stream_ts_as_string': {
-                    'timestamp': "1598434967.5782337"
+                    'timestamp': '1598434967.5782337'
                 },
                 'stream_ts_as_invalid_string': {
-                    'timestamp': "this-is-not-numeric"
+                    'timestamp': 'this-is-not-numeric'
                 }
             }
         }

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -2,7 +2,8 @@ import os
 import time
 import pytest
 
-from tap_kafka.local_store import LocalStore, InvalidStateFileException
+from tap_kafka.local_store import LocalStore
+from tap_kafka.errors import InvalidStateFileException
 
 
 class TestLocalStore:
@@ -123,7 +124,8 @@ class TestLocalStore:
         assert local_store.count_all() == 12
 
     def test_get_timestamp_from_state(self):
-        """."""
+        """Timestamp in the state file should be auto-converted to
+        float whenever it's possible"""
         local_store = LocalStore(self.test_dir, 'my_stream_name')
         local_store.purge()
 

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,7 +1,8 @@
 import os
 import time
+import pytest
 
-from tap_kafka.local_store import LocalStore
+from tap_kafka.local_store import LocalStore, InvalidStateFileException
 
 
 class TestLocalStore:
@@ -120,3 +121,36 @@ class TestLocalStore:
         local_store.insert('{"type":"RECORD","value":{"col_1":"value_11"}}')
         local_store.insert('{"type":"RECORD","value":{"col_1":"value_12"}}')
         assert local_store.count_all() == 12
+
+    def test_get_timestamp_from_state(self):
+        """."""
+        local_store = LocalStore(self.test_dir, 'my_stream_name')
+        local_store.purge()
+
+        state = {
+            'bookmarks': {
+                'stream_ts_as_number': {
+                    'timestamp': 1598434967.5782337
+                },
+                'stream_ts_as_string': {
+                    'timestamp': "1598434967.5782337"
+                },
+                'stream_ts_as_invalid_string': {
+                    'timestamp': "this-is-not-numeric"
+                }
+            }
+        }
+
+        # Timestamp should be float
+        ts = local_store._get_timestamp_from_state(state, 'stream_ts_as_number')
+        assert isinstance(ts, float)
+        assert ts == 1598434967.5782337
+
+        # Timestamp should be converted from string to float
+        ts = local_store._get_timestamp_from_state(state, 'stream_ts_as_string')
+        assert isinstance(ts, float)
+        assert ts == 1598434967.5782337
+
+        # Timestamp that cannot be converted to float should raise exception
+        with pytest.raises(InvalidStateFileException):
+            local_store._get_timestamp_from_state(state, 'stream_ts_as_invalid_string')

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -124,7 +124,7 @@ class TestLocalStore:
         assert local_store.count_all() == 12
 
     def test_get_timestamp_from_state(self):
-        """Timestamp in the state file should be auto-converted to
+        """Timestamp in the bookmark should be auto-converted to
         float whenever it's possible"""
         local_store = LocalStore(self.test_dir, 'my_stream_name')
         local_store.purge()

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -323,7 +323,7 @@ class TestSync(object):
                 'test-topic-1': {'timestamp': 222}}}
 
     def test_update_bookmark__not_numeric(self):
-        """Timestamp in the state file should be auto-converted to
+        """Timestamp in the bookmark should be auto-converted to
         float whenever it's possible"""
         input_state = {'bookmarks': {'test-topic-updated': {'timestamp': 111}}}
 

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import unittest
+import pytest
 from unittest.mock import patch
 
 from io import StringIO
@@ -9,6 +10,7 @@ from io import StringIO
 import tap_kafka
 from tap_kafka import common
 from tap_kafka import sync
+from tap_kafka.errors import InvalidStateFileException
 
 from tests.helper.parse_args_mock import ParseArgsMock
 from tests.helper.local_store_mock import LocalStoreMock
@@ -319,6 +321,19 @@ class TestSync(object):
             {'bookmarks': {
                 'test-topic-0': {'timestamp': 111},
                 'test-topic-1': {'timestamp': 222}}}
+
+    def test_update_bookmark__not_numeric(self):
+        """Timestamp in the state file should be auto-converted to
+        float whenever it's possible"""
+        input_state = {'bookmarks': {'test-topic-updated': {'timestamp': 111}}}
+
+        # Timestamp should be converted from string to float
+        assert sync.update_bookmark(input_state, 'test-topic-updated', '999.9999') == \
+            {'bookmarks': {'test-topic-updated': {'timestamp': 999.9999}}}
+
+        # Timestamp that cannot be converted to float should raise exception
+        with pytest.raises(InvalidStateFileException):
+            sync.update_bookmark(input_state, 'test-topic-updated', 'this-is-not-numeric')
 
     @patch('tap_kafka.sync.commit_kafka_consumer')
     def test_consuming_records_with_no_state(self, commit_kafka_consumer_mock):

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -10,7 +10,7 @@ from io import StringIO
 import tap_kafka
 from tap_kafka import common
 from tap_kafka import sync
-from tap_kafka.errors import InvalidStateFileException
+from tap_kafka.errors import InvalidBookmarkException
 
 from tests.helper.parse_args_mock import ParseArgsMock
 from tests.helper.local_store_mock import LocalStoreMock
@@ -332,7 +332,7 @@ class TestSync(object):
             {'bookmarks': {'test-topic-updated': {'timestamp': 999.9999}}}
 
         # Timestamp that cannot be converted to float should raise exception
-        with pytest.raises(InvalidStateFileException):
+        with pytest.raises(InvalidBookmarkException):
             sync.update_bookmark(input_state, 'test-topic-updated', 'this-is-not-numeric')
 
     @patch('tap_kafka.sync.commit_kafka_consumer')


### PR DESCRIPTION
## Problem

Timestamp in the state file sometimes written as quoted strings and tap failing with this error:
```
time=2020-08-06 09:00:35 logger_name=tap_kafka log_level=CRITICAL message='>' not supported between instances of 'float' and 'str'
```

This is because the bookmark in the `state.json` file written as string and not as numeric value:
```
{"bookmarks": {"VerificationService.Analytics.TriggeredCredentialsAndEntitlements": {"timestamp": "1596698218.5782337"}}}
```

## Proposed changes

Auto-convert timestamp in the state file to floating-point numbers when writing and when reading it.
If timestamp cannot be converted, raise a new custom exception: `InvalidStateFileException`.

