### PR TITLE
[AP-786] Use dpath instead of jsonpath_ng to extract PK(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or
   "group_id": "my_group",
   "topic": "my_topic",
   "primary_keys": {
-    "id": "$.jsonpath.to.primary_key"
+    "id": "/path/to/primary_key"
   }
 }
 ```
@@ -58,7 +58,7 @@ Full list of options in `config.json`:
 | bootstrap_servers                   | String  | Yes        | `host[:port]` string (or list of comma separated `host[:port]` strings) that the consumer should contact to bootstrap initial cluster metadata. |
 | group_id                            | String  | Yes        | The name of the consumer group to join for dynamic partition assignment (if enabled), and to use for fetching and committing offsets. |
 | topic                               | String  | Yes        | Name of kafka topics to subscribe to |
-| primary_keys                        | Object  |            | Optionally you can define primary key for the consumed messages. It requires a column name and JSONPath selector to extract the value from the kafka messages. The extracted column will be added to every output singer message. |
+| primary_keys                        | Object  |            | Optionally you can define primary key for the consumed messages. It requires a column name and `/slashed/paths` ala xpath selector to extract the value from the kafka messages. The extracted column will be added to every output singer message. |
 | max_runtime_ms                      | Integer |            | (Default: 300000) The maximum time for the tap to collect new messages from Kafka topic. If this time exceeds it will flush the batch and close kafka connection. |
 | batch_size_rows                     | Integer |            | (Default: 1000) Consumed kafka messages are transformed to batches and batches written to STDOUT in singer message format *only* when the batch is full. Set this value low to have more realtime experience. |
 | commit_interval_ms                  | Integer |            | (Default: 5000) Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store. |

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='pipelinewise-tap-kafka',
       install_requires=[
           'kafka-python==2.0.1',
           'pipelinewise-singer-python==1.*',
-          'jsonpath_ng==1.4.3',
+          'dpath==2.0.1',
           'filelock==3.0.12'
       ],
       extras_require={

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -441,7 +441,7 @@ class TestSync(object):
             'message_partition': 0
         }
 
-        # Converting with nested and multiple primary keys
+        # Converting with not existing primary keys
         message = KafkaMessage(value={'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
                                timestamp=123456789,
                                offset=1234,

--- a/tests/test_tap_kafka.py
+++ b/tests/test_tap_kafka.py
@@ -4,6 +4,7 @@ import json
 import unittest
 import pytest
 from unittest.mock import patch
+from collections import namedtuple
 
 from io import StringIO
 
@@ -392,6 +393,67 @@ class TestSync(object):
         # Kafka commit should be called once at the end, because
         # every message fits into one persisting batch size
         assert commit_kafka_consumer_mock.call_count == 1
+
+    def test_kafka_message_to_singer_record(self):
+        """Validate if kafka messages converted to singer messages correctly"""
+        KafkaMessage = namedtuple('KafkaMessage', 'value timestamp offset partition')
+        topic = 'test-topic'
+
+        # Converting without primary key
+        message = KafkaMessage(value={'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+                               timestamp=123456789,
+                               offset=1234,
+                               partition=0)
+        primary_keys = {}
+        assert sync.kafka_message_to_singer_record(message, topic, primary_keys) == {
+            'message': {'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+            'message_timestamp': 123456789,
+            'message_offset': 1234,
+            'message_partition': 0
+        }
+
+        # Converting with primary key
+        message = KafkaMessage(value={'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+                               timestamp=123456789,
+                               offset=1234,
+                               partition=0)
+        primary_keys = {'id': '/id'}
+        assert sync.kafka_message_to_singer_record(message, topic, primary_keys) == {
+            'message': {'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+            'id': 1,
+            'message_timestamp': 123456789,
+            'message_offset': 1234,
+            'message_partition': 0
+        }
+
+        # Converting with nested and multiple primary keys
+        message = KafkaMessage(value={'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+                               timestamp=123456789,
+                               offset=1234,
+                               partition=0)
+        primary_keys = {'id': '/id', 'y': '/data/y'}
+        assert sync.kafka_message_to_singer_record(message, topic, primary_keys) == {
+            'message': {'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+            'id': 1,
+            'y': 'value-y',
+            'message_timestamp': 123456789,
+            'message_offset': 1234,
+            'message_partition': 0
+        }
+
+        # Converting with nested and multiple primary keys
+        message = KafkaMessage(value={'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+                               timestamp=123456789,
+                               offset=1234,
+                               partition=0)
+        primary_keys = {'id': '/id', 'not-existing-key': '/path/not/exists'}
+        assert sync.kafka_message_to_singer_record(message, topic, primary_keys) == {
+            'message': {'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
+            'id': 1,
+            'message_timestamp': 123456789,
+            'message_offset': 1234,
+            'message_partition': 0
+        }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

If the tap is using the optional `primary_keys` feature, then the tap is running slow and can process only at about 10.000 message/minute. The tap is using [jsonpath-ng](https://github.com/h2non/jsonpath-ng) to extract primary key from the kafka massage. It's working fine but the performance is not great.

## Solution

Switching to the much more lightweight [dpath-python](https://github.com/akesterson/dpath-python) to extract PKs from python dictionaries. dpath-python is searching in the pure python dictionaries via `/slashed/paths` ala xpath selectors and performs 10x faster on the same dataset.

`/slashed/paths`type of selectors are not as feature rich as jsonpath selectors but extracting the PKs doesn't require all the jsonpath features.

##

This is a breaking change and every PPW kafka taps that's having the `primary_keys` option should be re-configured:

From:
```
  primary_keys:
    id: "$.payload.id"
    type: "$.payload.type"
```

To:
```
  primary_keys:
    id: "/payload/id"
    type: "/payload/type"
```