### PR TITLE
feat: make it possible to use catalog args.

### DIFF
--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -100,9 +100,10 @@ def main_impl():
 
     if args.discover:
         do_discovery(args.config)
-    elif args.properties:
+    elif args.properties or args.catalog:
         state = args.state or {}
-        sync.do_sync(kafka_config, args.properties, state, fn_get_args=get_args)
+        sync.do_sync(kafka_config, args.catalog.to_dict() if args.catalog else args.properties, state,
+                     fn_get_args=get_args)
     else:
         LOGGER.info("No properties were selected")
 


### PR DESCRIPTION
## Problem

Properties for schema definitions is deprecated, and you can't use catalog for schema definitions.

## Proposed changes

Check that catalog exists, and if it does try using it, otherwise fall back to properties.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions