### PR TITLE
Avro deserializer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.20.0
 strict-rfc3339==0.7
 nose==1.3.7
 jsonschema==2.6.0
+kafkian=0.13.0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(name='pipelinewise-tap-kafka',
           'kafka-python==2.0.1',
           'pipelinewise-singer-python==1.*',
           'dpath==2.0.1',
-          'filelock==3.0.12'
+          'filelock==3.0.12',
+          'kafkian==0.13.0'
       ],
       extras_require={
           "test": [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-kafka',
-      version='4.0.0',
+      version='4.1.0',
       description='Singer.io tap for extracting data from Kafka topic - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -10,7 +10,7 @@ from kafka import KafkaConsumer
 import tap_kafka.sync as sync
 import tap_kafka.common as common
 
-LOGGER = singer.get_logger('tap_kafka')
+LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'bootstrap_servers',
@@ -42,11 +42,20 @@ def do_discovery(config):
     """Discover kafka topic by trying to connect to the topic and generate singer schema
     according to the config"""
     try:
+        if "avro_schema" in config and config["avro_schema"]:
+            LOGGER.info(f"avro_schema value set to {config['avro_schema']}, using avro deserializer.")
+            from kafkian.serde.deserialization import AvroDeserializer
+            avd = AvroDeserializer(schema_registry_url=config['avro_schema'])
+            deserializer = avd.deserialize
+        else:
+            def deserializer(m):
+                return json.loads(m.decode(config['encoding']))
         consumer = KafkaConsumer(config['topic'],
                                  group_id=config['group_id'],
                                  enable_auto_commit=False,
                                  consumer_timeout_ms=config['consumer_timeout_ms'],
-                                 # value_deserializer=lambda m: json.loads(m.decode('ascii'))
+                                 security_protocol=config['security_protocol'],
+                                 value_deserializer=deserializer,
                                  bootstrap_servers=config['bootstrap_servers'].split(','))
 
     except Exception as ex:
@@ -89,7 +98,9 @@ def generate_config(args_config):
         'encoding': args_config.get('encoding', DEFAULT_ENCODING),
         'local_store_dir': args_config.get('local_store_dir', DEFAULT_LOCAL_STORE_DIR),
         'local_store_batch_size_rows': args_config.get('local_store_batch_size_rows',
-                                                       DEFAULT_LOCAL_STORE_BATCH_SIZE_ROWS)
+                                                       DEFAULT_LOCAL_STORE_BATCH_SIZE_ROWS),
+        'avro_schema': args_config.get('avro_schema', ''),
+        'security_protocol': args_config.get('security_protocol', 'SSL')
     }
 
 


### PR DESCRIPTION
## Problem

Currently there is not a way to configure Avro deserializer as a deserializer or to configure the security protocol.

## Proposed changes

In the approach I am taking, the avro schema is passed as a config property, when the consumer is constructed we pass the avro deserializer as a param if the property is set or fallback to the default deserializer.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions