### PR TITLE
[AP-1060] Compatibility with singer-python-2.x and confluent-kafka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ ZOOKEEPER_CLIENT_PORT = 2181
 KAFKA_PORT = 29092
 
 .run_pytest_unit:
-	@$(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=75 tests/unit -v
+	@$(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=76 tests/unit -v
 
 .run_pytest_integration:
-	@TAP_KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT} $(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=77 tests/integration -v
+	@TAP_KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT} $(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=78 tests/integration -v
 
 virtual_env:
 	@echo "Making Virtual Environment in $(VENV_DIR)..."

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='pipelinewise-tap-kafka',
           'Programming Language :: Python :: 3 :: Only'
       ],
       install_requires=[
-          'pipelinewise-singer-python==1.*',
+          'pipelinewise-singer-python==2.*',
           'dpath==2.0.1',
           'filelock==3.0.12',
           'confluent-kafka==1.7.0'

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -17,3 +17,10 @@ class InvalidTimestampException(Exception):
     Exception to raise when a kafka timestamp tuple is invalid
     """
     pass
+
+
+class TimestampNotAvailableException(Exception):
+    """
+    Exception to raise when timestamp not available in a kafka message
+    """
+    pass

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -10,3 +10,10 @@ class DiscoveryException(Exception):
     Exception to raise when discovery failed
     """
     pass
+
+
+class InvalidTimestampException(Exception):
+    """
+    Exception to raise when a kafka timestamp tuple is invalid
+    """
+    pass

--- a/tap_kafka/local_store.py
+++ b/tap_kafka/local_store.py
@@ -137,7 +137,13 @@ class LocalStore:
         """Insert a new message with a generated timestamp
         Returns the last timestamp of the last inserted message"""
         # Add to the in-memory batch to avoid too frequent I/O write
-        self.messages_to_persist.append(message)
+        message_to_append = message
+        if isinstance(message, bytes):
+            message_to_append = message.decode('utf-8')
+        else:
+            message_to_append = message
+
+        self.messages_to_persist.append(message_to_append)
         self.last_inserted_ts = time.time()
 
         # Write to disk if in-memory batch is full

--- a/tap_kafka/local_store.py
+++ b/tap_kafka/local_store.py
@@ -140,8 +140,6 @@ class LocalStore:
         message_to_append = message
         if isinstance(message, bytes):
             message_to_append = message.decode('utf-8')
-        else:
-            message_to_append = message
 
         self.messages_to_persist.append(message_to_append)
         self.last_inserted_ts = time.time()

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -5,7 +5,7 @@ from confluent_kafka.serialization import SerializationError
 
 class JSONSimpleDeserializer(Deserializer):
     """
-    Deserializes Python objects from JSON formatted bytes.
+    Deserializes a Python object from JSON formatted bytes.
     """
 
     def __init__(self):
@@ -13,7 +13,7 @@ class JSONSimpleDeserializer(Deserializer):
 
     def __call__(self, value, ctx):
         """
-        Deserializes Python objects from JSON formatted bytes
+        Deserializes a Python object from JSON formatted bytes
         Args:
             value (bytes): bytes to be deserialized
             ctx (SerializationContext): Metadata pertaining to the serialization

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -5,7 +5,7 @@ from confluent_kafka.serialization import SerializationError
 
 class JSONSimpleDeserializer(Deserializer):
     """
-    Deserializes a Python objects from JSON bytes.
+    Deserializes Python objects from JSON formatted bytes.
     """
 
     def __init__(self):

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -1,0 +1,32 @@
+import orjson
+from confluent_kafka.serialization import Deserializer
+from confluent_kafka.serialization import SerializationError
+
+
+class JSONSimpleDeserializer(Deserializer):
+    """
+    Deserializes a Python objects from JSON bytes.
+    """  # noqa: E501
+
+    def __init__(self):
+        pass
+
+    def __call__(self, value, ctx):
+        """
+        Serializes unicode to bytes per the configured codec. Defaults to ``utf_8``.
+        Args:
+            value (bytes): bytes to be deserialized
+            ctx (SerializationContext): Metadata pertaining to the serialization
+                operation
+        Raises:
+            SerializerError if an error occurs during deserialization.
+        Returns:
+            Python object if data is not None, otherwise None
+        """
+        if value is None:
+            return None
+
+        try:
+            return orjson.loads(value)
+        except orjson.JSONDecodeError as e:
+            raise SerializationError(str(e))

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -13,7 +13,7 @@ class JSONSimpleDeserializer(Deserializer):
 
     def __call__(self, value, ctx):
         """
-        Serializes unicode to bytes per the configured codec. Defaults to ``utf_8``.
+        Deserializes Python objects from JSON formatted bytes
         Args:
             value (bytes): bytes to be deserialized
             ctx (SerializationContext): Metadata pertaining to the serialization

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -6,7 +6,7 @@ from confluent_kafka.serialization import SerializationError
 class JSONSimpleDeserializer(Deserializer):
     """
     Deserializes a Python objects from JSON bytes.
-    """  # noqa: E501
+    """
 
     def __init__(self):
         pass

--- a/tap_kafka/serialization/json_with_no_schema.py
+++ b/tap_kafka/serialization/json_with_no_schema.py
@@ -7,10 +7,6 @@ class JSONSimpleDeserializer(Deserializer):
     """
     Deserializes a Python object from JSON formatted bytes.
     """
-
-    def __init__(self):
-        pass
-
     def __call__(self, value, ctx):
         """
         Deserializes a Python object from JSON formatted bytes

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -91,12 +91,9 @@ def init_kafka_consumer(kafka_config):
     return consumer
 
 
-def get_timestamp_from_timestamp_tuple(kafka_ts):
-    """Get the actual timestamp value from a kafka timestamp tuple
-
-    It accepts tuple and list to be compatible with JSON serialised kafka messages as well
-    """
-    if isinstance(kafka_ts, (list, tuple)):
+def get_timestamp_from_timestamp_tuple(kafka_ts: tuple) -> float:
+    """Get the actual timestamp value from a kafka timestamp tuple"""
+    if isinstance(kafka_ts, tuple):
         ts_type = kafka_ts[0]
 
         if ts_type == confluent_kafka.TIMESTAMP_NOT_AVAILABLE:

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -7,7 +7,7 @@ import singer
 import confluent_kafka
 
 from singer import utils, metadata
-from tap_kafka.errors import InvalidTimestampException
+from tap_kafka.errors import InvalidTimestampException, TimestampNotAvailableException
 from tap_kafka.local_store import LocalStore
 from tap_kafka.serialization.json_with_no_schema import JSONSimpleDeserializer
 
@@ -97,7 +97,7 @@ def get_timestamp_from_timestamp_tuple(kafka_ts: tuple) -> float:
         ts_type = kafka_ts[0]
 
         if ts_type == confluent_kafka.TIMESTAMP_NOT_AVAILABLE:
-            return 0
+            raise TimestampNotAvailableException('Required timestamp not available in the kafka message.')
 
         if ts_type in [confluent_kafka.TIMESTAMP_CREATE_TIME, confluent_kafka.TIMESTAMP_LOG_APPEND_TIME]:
             return kafka_ts[1]

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -176,9 +176,8 @@ def read_kafka_topic(consumer, local_store, kafka_config, state, fn_get_args):
             break
 
         message = polled_message
-        LOGGER.debug("%s:%s:%s: key=%s value=%s" % (message.topic(), message.partition(),
-                                                   message.offset(), message.key(),
-                                                   message.value()))
+        LOGGER.debug("%s:%s:%s: key=%s value=<HIDDEN>" % (message.topic(), message.partition(),
+                                                          message.offset(), message.key()))
 
         # Initialise the start time after the first message
         if not start_time:

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -1,13 +1,15 @@
 """Sync functions that consumes and transforms kafka messages to singer messages"""
-import json
 import time
 import copy
 import dpath.util
 
 import singer
+import confluent_kafka
+
 from singer import utils, metadata
+from tap_kafka.errors import InvalidTimestampException
 from tap_kafka.local_store import LocalStore
-from confluent_kafka import Consumer
+from tap_kafka.serialization.json_with_no_schema import JSONSimpleDeserializer
 
 from .errors import InvalidBookmarkException
 
@@ -69,7 +71,7 @@ def init_local_store(kafka_config):
 
 def init_kafka_consumer(kafka_config):
     LOGGER.info('Initialising Kafka Consumer...')
-    consumer = Consumer({
+    consumer = confluent_kafka.DeserializingConsumer({
         # Required parameters
         'bootstrap.servers': kafka_config['bootstrap_servers'],
         'group.id': kafka_config['group_id'],
@@ -82,10 +84,30 @@ def init_kafka_consumer(kafka_config):
         # Non-configurable parameters
         'enable.auto.commit': False,
         'auto.offset.reset': 'earliest',
+        'value.deserializer': JSONSimpleDeserializer(),
     })
     consumer.subscribe([kafka_config['topic']])
 
     return consumer
+
+
+def get_timestamp_from_timestamp_tuple(kafka_ts):
+    """Get the actual timestamp value from a kafka timestamp tuple
+
+    It accepts tuple and list to be compatible with JSON serialised kafka messages as well
+    """
+    if isinstance(kafka_ts, tuple) or isinstance(kafka_ts, list):
+        ts_type = kafka_ts[0]
+
+        if ts_type == confluent_kafka.TIMESTAMP_NOT_AVAILABLE:
+            return 0
+
+        if ts_type in [confluent_kafka.TIMESTAMP_CREATE_TIME, confluent_kafka.TIMESTAMP_LOG_APPEND_TIME]:
+            return kafka_ts[1]
+
+        raise InvalidTimestampException(f'Invalid timestamp tuple. Timestamp type {ts_type} is not valid.')
+
+    raise InvalidTimestampException(f'Invalid kafka timestamp. It needs to be a tuple but it is a {type(kafka_ts)}.')
 
 
 def kafka_message_to_singer_record(message, topic, primary_keys):
@@ -93,7 +115,7 @@ def kafka_message_to_singer_record(message, topic, primary_keys):
     # Create dictionary with base attributes
     record = {
         "message": message.value(),
-        "message_timestamp": message.timestamp(),
+        "message_timestamp": get_timestamp_from_timestamp_tuple(message.timestamp()),
         "message_offset": message.offset(),
         "message_partition": message.partition()
     }
@@ -157,7 +179,7 @@ def read_kafka_topic(consumer, local_store, kafka_config, state, fn_get_args):
             break
 
         message = polled_message
-        LOGGER.info("%s:%s:%s: key=%s value=%s" % (message.topic(), message.partition(),
+        LOGGER.debug("%s:%s:%s: key=%s value=%s" % (message.topic(), message.partition(),
                                                    message.offset(), message.key(),
                                                    message.value()))
 

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -96,7 +96,7 @@ def get_timestamp_from_timestamp_tuple(kafka_ts):
 
     It accepts tuple and list to be compatible with JSON serialised kafka messages as well
     """
-    if isinstance(kafka_ts, tuple) or isinstance(kafka_ts, list):
+    if isinstance(kafka_ts, (list, tuple)):
         ts_type = kafka_ts[0]
 
         if ts_type == confluent_kafka.TIMESTAMP_NOT_AVAILABLE:

--- a/tests/unit/resources/kafka-messages-from-multiple-partitions.json
+++ b/tests/unit/resources/kafka-messages-from-multiple-partitions.json
@@ -3,21 +3,21 @@
       "topic": "dummy_topic",
       "offset": 1,
       "partition": 1,
-      "timestamp": 1575895711187,
+      "timestamp": [1, 1575895711187],
       "value": {"result": "SUCCESS", "details": {"id": "1001", "type": "TYPE_1", "profileId": 1234}}
   },
   {
       "topic": "dummy_topic",
       "offset": 2,
       "partition": 2,
-      "timestamp": 1575895711187,
+      "timestamp": [1, 1575895711187],
       "value": {"result": "SUCCESS", "details": {"id": "1002", "type": "TYPE_2", "profileId": 1234}}
   },
   {
       "topic": "dummy_topic",
       "offset": 3,
       "partition": 2,
-      "timestamp": 1575895711187,
+      "timestamp": [1, 1575895711187],
       "value": {"result": "SUCCESS", "details": {"id": "1003", "type": "TYPE_3", "profileId": 1234}}
   }
 ]

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -1,0 +1,16 @@
+import pytest
+
+from confluent_kafka.serialization import SerializationError
+from tap_kafka.serialization.json_with_no_schema import JSONSimpleDeserializer
+
+
+class TestSerializers(object):
+    def test_generate_config_with_defaults(self):
+        deserializer = JSONSimpleDeserializer()
+
+        assert deserializer(value=None, ctx=None) is None
+        assert deserializer(value='{}', ctx=None) == {}
+        assert deserializer(value='{"abc": 123}', ctx=None) == {'abc': 123}
+
+        with pytest.raises(SerializationError):
+            deserializer(value='invalid-json', ctx=None)


### PR DESCRIPTION
## Problem

[pipelinewise-singer-python 2.0](https://github.com/transferwise/pipelinewise-singer-python/) introduced the faster orjson library. This PR makes it to start using it and improves the compatibility with the `confluent-kafka` library

## Proposed changes

Making tap-kafka to be compatible with `pipelinewise-singer-python 2.0.x` and `confluent-kafka` libs:

* Introducing [JSONSimpleDeserializer](https://github.com/transferwise/pipelinewise-tap-kafka/pull/49/files#diff-5b1a7c1d42151ce4e039a65e5a04308a294c1166c4c37c6da237331826796791R6): This is a custom schemaless json deserializer that's using orjson to parse jsons. This is required because the [confluent-kafka JSONDeserializer](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#jsondeserializer)  requires a schema and using the default python json parser. We want to have a schemaless option with a faster json parser.
* Introducing [get_timestamp_from_timestamp_tuple](https://github.com/transferwise/pipelinewise-tap-kafka/pull/49/files#diff-83599c4cf950aeed1b29025f7cc1a17837569a266f88cd1785d355a5faae48cfR94): The confluent-kafka library returns message timestamps as a tuple of `type` and `timestamp` (doc [here](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Message.timestamp)). Previously in the kafka-python library it was only a timestamp. Without this change the timestamps are not extracted correctly from the consumed messages.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions