### PR TITLE
Bump pylint from 2.4.2 to 2.12.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='pipelinewise-tap-kafka',
       extras_require={
           'test': [
               'pytest==6.2.5',
-              'pylint==2.4.2',
+              'pylint==2.12.2',
               'pytest-cov==3.0.0'
           ]
       },

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -7,8 +7,8 @@ import singer
 from singer import utils
 from confluent_kafka import Consumer, KafkaException
 
-import tap_kafka.sync as sync
-import tap_kafka.common as common
+from tap_kafka import sync
+from tap_kafka import common
 
 from .errors import InvalidTimestampException, InvalidConfigException, DiscoveryException
 


### PR DESCRIPTION
## Problem

Current pylint is getting old and reported by dependabot at https://github.com/transferwise/pipelinewise-tap-kafka/pull/53

## Proposed changes

Bumps pylint from 2.4.2 to 2.12.2.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions