### PR TITLE
Raise exception on all brokers down

### DIFF
--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -45,3 +45,9 @@ class ProtobufCompilerException(Exception):
     Exception to raise when protobuf compiler fails
     """
     pass
+
+class AllBrokersDownException(Exception):
+    """
+    Exception to raise when kafka broker is not available
+    """
+    pass

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -7,7 +7,10 @@ import dateutil
 import singer
 import confluent_kafka
 
+from confluent_kafka import KafkaError
+
 from singer import utils, metadata
+from tap_kafka.errors import AllBrokersDownException
 from tap_kafka.errors import InvalidBookmarkException
 from tap_kafka.errors import InvalidConfigException
 from tap_kafka.errors import InvalidTimestampException
@@ -108,6 +111,10 @@ def assign_consumer(consumer, topic: str, state: dict, initial_start_time: str) 
     elif initial_start_time is not None and initial_start_time not in ['latest', 'earliest']:
         assign_consumer_to_timestamp(consumer, topic, initial_start_time)
 
+def error_callback(error: KafkaError):
+    print(error)
+    if error.code() == KafkaError._ALL_BROKERS_DOWN:
+        raise AllBrokersDownException('All kafka brokers are down')
 
 def init_kafka_consumer(kafka_config, state, value_deserializer):
     LOGGER.info('Initialising Kafka Consumer...')
@@ -117,6 +124,7 @@ def init_kafka_consumer(kafka_config, state, value_deserializer):
         # Required parameters
         'bootstrap.servers': kafka_config['bootstrap_servers'],
         'group.id': kafka_config['group_id'],
+        'error_cb': error_callback,
 
         # Optional parameters
         'session.timeout.ms': kafka_config['session_timeout_ms'],

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -112,7 +112,6 @@ def assign_consumer(consumer, topic: str, state: dict, initial_start_time: str) 
         assign_consumer_to_timestamp(consumer, topic, initial_start_time)
 
 def error_callback(error: KafkaError):
-    print(error)
     if error.code() == KafkaError._ALL_BROKERS_DOWN:
         raise AllBrokersDownException('All kafka brokers are down')
 

--- a/tests/integration/test_consumer.py
+++ b/tests/integration/test_consumer.py
@@ -81,9 +81,10 @@ class TestKafkaConsumer(unittest.TestCase):
 
     def test_tap_kafka_consumer_brokers_down(self):
         # Consume test messages from not existing broker
+        topic = 'foo'
         tap_kafka_config = tap_kafka.generate_config({
             'bootstrap_servers': 'localhost:12345',
-            'topic': 'foo',
+            'topic': topic,
             'group_id': test_utils.generate_unique_consumer_group(),
         })
         catalog = {'streams': tap_kafka.common.generate_catalog(tap_kafka_config)}

--- a/tests/integration/test_consumer.py
+++ b/tests/integration/test_consumer.py
@@ -6,6 +6,7 @@ import singer
 import tap_kafka.serialization
 
 from tap_kafka import sync, get_args
+from tap_kafka.errors import AllBrokersDownException
 from tap_kafka.errors import DiscoveryException
 from tap_kafka.serialization.json_with_no_schema import JSONSimpleSerializer
 import tests.integration.utils as test_utils
@@ -77,6 +78,18 @@ class TestKafkaConsumer(unittest.TestCase):
 
         with self.assertRaises(DiscoveryException):
             tap_kafka.do_discovery(tap_kafka_config)
+
+    def test_tap_kafka_consumer_brokers_down(self):
+        # Consume test messages from not existing broker
+        tap_kafka_config = tap_kafka.generate_config({
+            'bootstrap_servers': 'localhost:12345',
+            'topic': 'foo',
+            'group_id': test_utils.generate_unique_consumer_group(),
+        })
+        catalog = {'streams': tap_kafka.common.generate_catalog(tap_kafka_config)}
+
+        with self.assertRaises(AllBrokersDownException):
+            sync.do_sync(tap_kafka_config, catalog, state={'bookmarks': {topic: {}}})
 
     def test_tap_kafka_consumer(self):
         kafka_config = test_utils.get_kafka_config()


### PR DESCRIPTION
## Problem

The consumer doesn't raise exception if the brokers are down.

## Proposed changes

Catch `_ALL_BROKERS_DOWN` kafka error and raise exception.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions