### PR TITLE
Raise exception if custom PK not exists in the message

### DIFF
--- a/tap_kafka/common.py
+++ b/tap_kafka/common.py
@@ -22,7 +22,7 @@ def generate_schema(primary_keys) -> object:
 
     # Primary keys are dynamic schema items
     for key in primary_keys:
-        schema["properties"][key] = {"type": ["string", "null"]}
+        schema["properties"][key] = {"type": ["string"]}
 
     return schema
 

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -51,3 +51,9 @@ class AllBrokersDownException(Exception):
     Exception to raise when kafka broker is not available
     """
     pass
+
+class PrimaryKeyNotFoundException(Exception):
+    """
+    Exception to raise if the custom primary key not found in the message
+    """
+    pass

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -16,6 +16,7 @@ from tap_kafka.errors import InvalidConfigException
 from tap_kafka.errors import InvalidTimestampException
 from tap_kafka.errors import TimestampNotAvailableException
 from tap_kafka.errors import InvalidAssignByKeyException
+from tap_kafka.errors import PrimaryKeyNotFoundException
 from tap_kafka.serialization.json_with_no_schema import JSONSimpleDeserializer
 from tap_kafka.serialization.protobuf import ProtobufDictDeserializer
 from tap_kafka.serialization.protobuf import proto_to_message_type
@@ -185,10 +186,8 @@ def kafka_message_to_singer_record(message, primary_keys):
         pk_selector = primary_keys[key]
         try:
             record[key] = dpath.util.get(message.value(), pk_selector)
-        # Do not fail if PK not found in the message.
-        # Continue without adding the extracted PK to the message
         except KeyError:
-            pass
+            raise PrimaryKeyNotFoundException(f"Custom primary key not found in the message: '{pk_selector}'")
 
     return record
 

--- a/tests/integration/test_consumer.py
+++ b/tests/integration/test_consumer.py
@@ -135,7 +135,7 @@ class TestKafkaConsumer(unittest.TestCase):
                         'message_offset': {'type': ['integer', 'null']},
                         'message_timestamp': {'type': ['integer', 'string', 'null']},
                         'message': {'type': ['object', 'array', 'string', 'null']},
-                        'id': {'type': ['string', 'null']}
+                        'id': {'type': ['string']}
                     }
                 },
                 'key_properties': ['id']
@@ -167,7 +167,7 @@ class TestKafkaConsumer(unittest.TestCase):
                         'message_offset': {'type': ['integer', 'null']},
                         'message_timestamp': {'type': ['integer', 'string', 'null']},
                         'message': {'type': ['object', 'array', 'string', 'null']},
-                        'id': {'type': ['string', 'null']}
+                        'id': {'type': ['string']}
                     }
                 },
                 'key_properties': ['id']
@@ -282,7 +282,7 @@ class TestKafkaConsumer(unittest.TestCase):
                         'message_offset': {'type': ['integer', 'null']},
                         'message_timestamp': {'type': ['integer', 'string', 'null']},
                         'message': {'type': ['object', 'array', 'string', 'null']},
-                        'id': {'type': ['string', 'null']}
+                        'id': {'type': ['string']}
                     }
                 },
                 'key_properties': ['id']

--- a/tests/unit/resources/catalog.json
+++ b/tests/unit/resources/catalog.json
@@ -16,8 +16,7 @@
             "properties":{
                "id":{
                   "type":[
-                     "string",
-                     "null"
+                     "string"
                   ]
                },
                "message_timestamp":{

--- a/tests/unit/test_tap_kafka.py
+++ b/tests/unit/test_tap_kafka.py
@@ -467,7 +467,7 @@ class TestSync(unittest.TestCase):
                 'schema': {
                     'type': 'object',
                     'properties': {
-                        'id': {'type': ['string', 'null']},
+                        'id': {'type': ['string']},
                         'message_partition': {'type': ['integer', 'null']},
                         'message_offset': {'type': ['integer', 'null']},
                         'message_timestamp': {'type': ['integer', 'string', 'null']},

--- a/tests/unit/test_tap_kafka.py
+++ b/tests/unit/test_tap_kafka.py
@@ -258,7 +258,7 @@ class TestSync(unittest.TestCase):
             {
                 "type": "object",
                 "properties": {
-                    "id": {"type": ["string", "null"]},
+                    "id": {"type": ["string"]},
                     "message_timestamp": {"type": ["integer", "string", "null"]},
                     "message_offset": {"type": ["integer", "null"]},
                     "message_partition": {"type": ["integer", "null"]},
@@ -272,8 +272,8 @@ class TestSync(unittest.TestCase):
             {
                 "type": "object",
                 "properties": {
-                    "id": {"type": ["string", "null"]},
-                    "version": {"type": ["string", "null"]},
+                    "id": {"type": ["string"]},
+                    "version": {"type": ["string"]},
                     "message_timestamp": {"type": ["integer", "string", "null"]},
                     "message_offset": {"type": ["integer", "null"]},
                     "message_partition": {"type": ["integer", "null"]},
@@ -319,7 +319,7 @@ class TestSync(unittest.TestCase):
                        "schema": {
                            "type": "object",
                            "properties": {
-                                "id": {"type": ["string", "null"]},
+                                "id": {"type": ["string"]},
                                 "message_timestamp": {"type": ["integer", "string", "null"]},
                                 "message_offset": {"type": ["integer", "null"]},
                                 "message_partition": {"type": ["integer", "null"]},
@@ -347,8 +347,8 @@ class TestSync(unittest.TestCase):
                        "schema": {
                            "type": "object",
                            "properties": {
-                                "id": {"type": ["string", "null"]},
-                                "version": {"type": ["string", "null"]},
+                                "id": {"type": ["string"]},
+                                "version": {"type": ["string"]},
                                 "message_timestamp": {"type": ["integer", "string", "null"]},
                                 "message_offset": {"type": ["integer", "null"]},
                                 "message_partition": {"type": ["integer", "null"]},

--- a/tests/unit/test_tap_kafka.py
+++ b/tests/unit/test_tap_kafka.py
@@ -15,7 +15,8 @@ from tap_kafka.errors import (
     InvalidBookmarkException,
     InvalidTimestampException,
     InvalidAssignByKeyException,
-    TimestampNotAvailableException
+    TimestampNotAvailableException,
+    PrimaryKeyNotFoundException,
 )
 import confluent_kafka
 
@@ -797,13 +798,9 @@ class TestSync(unittest.TestCase):
                                            offset=1234,
                                            partition=0)
         primary_keys = {'id': '/id', 'not-existing-key': '/path/not/exists'}
-        self.assertEqual(sync.kafka_message_to_singer_record(message, primary_keys), {
-            'message': {'id': 1, 'data': {'x': 'value-x', 'y': 'value-y'}},
-            'id': 1,
-            'message_timestamp': 123456789,
-            'message_offset': 1234,
-            'message_partition': 0
-        })
+
+        with self.assertRaises(PrimaryKeyNotFoundException):
+            sync.kafka_message_to_singer_record(message, primary_keys)
 
     def test_commit_consumer_to_bookmarked_state(self):
         """Commit should commit every partition in the bookmark state"""


### PR DESCRIPTION
## Problem

Currently the tap doesn't fail if the custom primary key not exists in the consumed kafka message. This used to be an expected behavior but turns out this is not great and causing misleading error messages when the target connector is trying to process the singer messages.

## Proposed changes

Change behavior and raise exception if the custom primary key not exists in the consumed kafka messages.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions