### PR TITLE
Add singer and runtime files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.egg-info/
 *__pycache__/
 *~
+build/
 dist/
 test_dir/
 tap-kafka-proto-classes/
@@ -18,6 +19,7 @@ tap-kafka-proto-classes/
 
 # Singer JSON files
 properties.json
+catalog.json
 config.json
 state.json
 


### PR DESCRIPTION
## Problem

The `build/` directory and `catalog.json` files are needed for local testing and development, but doesn't need to be checked into the repo

## Proposed changes

Add singer and runtime files to `.gitignore`


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Housekeeping


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions