### PR TITLE
Optionally specify partitions in configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,5 @@ jobs:
       - name: Pylinting
         run: make lint
 
-      - name: Unit Tests
-        run: make unit_test
-
-      - name: Integration Tests
-        run: make integration_test
+      - name: Tests
+        run: make all_test

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ KAFKA_PORT = 29092
 SCHEMA_REGISTRY_PORT = 8081
 
 .run_pytest_unit:
-	@$(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=78 tests/unit -v
+	@$(VENV_DIR)/bin/pytest --verbose --cov=tap_kafka --cov-fail-under=80 --cov-report term-missing tests/unit
 
 .run_pytest_integration:
-	@TAP_KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT} $(VENV_DIR)/bin/pytest --cov=tap_kafka  --cov-fail-under=79 tests/integration -v
+	@TAP_KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT} $(VENV_DIR)/bin/pytest --verbose --cov=tap_kafka --cov-fail-under=80 --cov-report term-missing tests/integration
+
+.run_pytest_all:
+	@TAP_KAFKA_BOOTSTRAP_SERVERS=localhost:${KAFKA_PORT} $(VENV_DIR)/bin/pytest --verbose --cov=tap_kafka --cov-fail-under=80 --cov-report term-missing tests/
 
 virtual_env:
 	@echo "Making Virtual Environment in $(VENV_DIR)..."
@@ -41,3 +44,5 @@ lint: virtual_env
 unit_test: virtual_env .run_pytest_unit
 
 integration_test: virtual_env start_containers .run_pytest_integration clean_containers
+
+all_test: virtual_env start_containers .run_pytest_all clean_containers

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Full list of options in `config.json`:
 |-----------------------------------|---------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | bootstrap_servers                 | String  | Yes        | `host[:port]` string (or list of comma separated `host[:port]` strings) that the consumer should contact to bootstrap initial cluster metadata.                                                                                                     |
 | group_id                          | String  | Yes        | The name of the consumer group to join for dynamic partition assignment (if enabled), and to use for fetching and committing offsets.                                                                                                               |
-| topic                             | String  | Yes        | Name of kafka topics to subscribe to                                                                                                                                                                                                                |
+| topic                             | String  | Yes        | Name of kafka topic to subscribe to                                                                                                                                                                                                                 |
+| partitions                        | List    |            | (Default: [] (all)) Partition(s) of topic to consume, example `[0,4]`                                                                                                                                                                               |
 | primary_keys                      | Object  |            | Optionally you can define primary key for the consumed messages. It requires a column name and `/slashed/paths` ala xpath selector to extract the value from the kafka messages. The extracted column will be added to every output singer message. |
-| use_message_key                   | Bool    |            | (Default: true) Defines whether to use Kafka message key as a primary key for the record. Note: custom primary key(s) takes precedence if such defined and use_message_key is set to `true`.                                                        |
-| initial_start_time                | String  |            | (Default: latest) Start time reference of the message consumption if no bookmarked position in `state.sjon`. One of: `latest`, `earliest` or an ISO-8601 formatted timestamp string.                                                                |
+| use_message_key                   | Bool    |            | (Default: true) Defines whether to use Kafka message key as a primary key for the record. Note: if a custom primary key(s) has been defined, it will be used instead of the message_key.                                                            |
+| initial_start_time                | String  |            | (Default: latest) Start time reference of the message consumption if no bookmarked position in `state.json`. One of: `beginning`, `earliest`, `latest` or an ISO-8601 formatted timestamp string.                                                   |
 | max_runtime_ms                    | Integer |            | (Default: 300000) The maximum time for the tap to collect new messages from Kafka topic. If this time exceeds it will flush the batch and close kafka connection.                                                                                   |
 | commit_interval_ms                | Integer |            | (Default: 5000) Number of milliseconds between two commits. This is different than the kafka auto commit feature. Tap-kafka sends commit messages automatically but only when the data consumed successfully and persisted to local store.          |
 | consumer_timeout_ms               | Integer |            | (Default: 10000) KafkaConsumer setting. Number of milliseconds to block during message iteration before raising StopIteration                                                                                                                       |
@@ -83,7 +84,7 @@ This tap reads Kafka messages and generating singer compatible SCHEMA and RECORD
 | MESSAGE_KEY                 | (Optional) Added by default (can be overridden) in case no custom keys defined      |
 | DYNAMIC_PRIMARY_KEY(S)      | (Optional) Dynamically added primary key values, extracted from the Kafka message   |
 
- 
+
 ### Run the tap in Discovery Mode
 
 ```
@@ -126,7 +127,7 @@ The tap will write bookmarks to stdout which can be captured and passed as an op
   python3 -m venv venv
   . venv/bin/activate
   pip install --upgrade pip
-  pip install .[test]
+  pip install -e .[test]
 ```
 
 2. To run unit tests:
@@ -146,6 +147,6 @@ The tap will write bookmarks to stdout which can be captured and passed as an op
   python3 -m venv venv
   . venv/bin/activate
   pip install --upgrade pip
-  pip install .[test]
+  pip install -e .[test]
   pylint tap_kafka -d C,W,unexpected-keyword-arg,duplicate-code
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.2
+    image: confluentinc/cp-zookeeper:7.3.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -11,7 +11,7 @@ services:
       - tap_kafka_network
 
   kafka:
-    image: confluentinc/cp-kafka:5.5.2
+    image: confluentinc/cp-kafka:7.3.0
     depends_on:
       - zookeeper
     ports:
@@ -27,7 +27,7 @@ services:
       - tap_kafka_network
 
   schema_registry:
-    image: confluentinc/cp-schema-registry:5.5.2
+    image: confluentinc/cp-schema-registry:7.3.0
     depends_on:
       - zookeeper
       - kafka

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-kafka',
-      version='7.1.1',
+      version='8.0.0',
       description='Singer.io tap for extracting data from Kafka topic - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',
@@ -19,14 +19,14 @@ setup(name='pipelinewise-tap-kafka',
       install_requires=[
           'pipelinewise-singer-python==2.*',
           'dpath==2.0.6',
-          'confluent-kafka[protobuf]==1.9.0',
-          'grpcio-tools==1.44.0'
+          'confluent-kafka[protobuf]==1.9.2',
+          'grpcio-tools==1.51.1'
       ],
       extras_require={
           'test': [
-              'pytest==7.0.1',
-              'pylint==2.12.2',
-              'pytest-cov==3.0.0'
+              'pytest==7.2.0',
+              'pylint==2.15.7',
+              'pytest-cov==4.0.0'
           ]
       },
       entry_points='''

--- a/tap_kafka/errors.py
+++ b/tap_kafka/errors.py
@@ -33,13 +33,6 @@ class TimestampNotAvailableException(Exception):
     pass
 
 
-class InvalidAssignByKeyException(Exception):
-    """
-    Exception to raise when consumer assigned by an invalid option
-    """
-    pass
-
-
 class ProtobufCompilerException(Exception):
     """
     Exception to raise when protobuf compiler fails

--- a/tests/integration/test_protobuf.py
+++ b/tests/integration/test_protobuf.py
@@ -69,7 +69,8 @@ class TestProtobuf(unittest.TestCase):
             'bootstrap_servers': kafka_config['bootstrap_servers'],
             'topic': topic,
             'group_id': test_utils.generate_unique_consumer_group(),
-            'initial_start_time': 'earliest',
+            'consumer_timeout_ms': 1000,
+            'initial_start_time': 'beginning',
 
             # set protobuf message_format and proto_schema
             'message_format': 'protobuf',
@@ -81,8 +82,9 @@ class TestProtobuf(unittest.TestCase):
         singer_messages = []
         singer.write_message = lambda m: singer_messages.append(m.asdict())
 
-        sync.do_sync(tap_kafka_config, catalog, state={'bookmarks': {topic: {}}})
-        self.assertEqual(singer_messages, [
+        sync.do_sync(tap_kafka_config, catalog, state={})
+        self.assertEqual(len(singer_messages), 6)
+        self.assertListEqual(singer_messages, [
             {
                 'type': 'SCHEMA',
                 'stream': topic,

--- a/tests/unit/helper/kafka_consumer_mock.py
+++ b/tests/unit/helper/kafka_consumer_mock.py
@@ -1,4 +1,5 @@
 import os
+import confluent_kafka
 
 class KafkaConsumerMessageMock:
     def __init__(self, topic, value, timestamp=None, key=None, timestamp_type=0, partition=0, offset=1, headers=None,
@@ -76,3 +77,9 @@ class KafkaConsumerMock(object):
     def commit(self, offsets=None):
         if offsets:
             self.committed_offsets = offsets
+
+    def offsets_for_times(self, topic_partitions):
+        if topic_partitions[0].offset == 1638132327000:
+            topic_partitions[0].offset = 1234
+
+        return topic_partitions


### PR DESCRIPTION
## Problem

Currently tap-kafka only supports consuming messages from all partitions in a topic. Processing of the messages is handled by single thread and also produces a single thread of singer messages. These single threads are bottlenecks when consuming from a kafka topic that uses multiple partitions for read and write scaling.

## Proposed changes

Create the ability to specify which partitions should be consumed by a tap. This will allow running multiple taps in parallel that consume from the same topic, improving message processing and singer message production.

If no partitions are specified, tap-kafka will still consume all partitions in the topic.

## Problem

Currently tap-kafka only supports consuming messages from all partitions in a topic. Processing of the messages is handled by single thread and also produces a single thread of singer messages. These single threads are bottlenecks when consuming from a kafka topic that uses multiple partitions for read and write scaling.

## Proposed changes

Create the ability to specify which partitions should be consumed by a tap. This will allow running multiple taps in parallel that consume from the same topic, improving message processing and singer message production.

If no partitions are specified, tap-kafka will still consume all partitions in the topic.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Relevant documentation is updated including usage instructions


## Test coverage

```
---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                                             Stmts   Miss  Cover
--------------------------------------------------------------------
tap_kafka/__init__.py                               79     18    77%
tap_kafka/common.py                                 18      0   100%
tap_kafka/errors.py                                 16      0   100%
tap_kafka/serialization/__init__.py                  0      0   100%
tap_kafka/serialization/json_with_no_schema.py      20      3    85%
tap_kafka/serialization/protobuf.py                 43      2    95%
tap_kafka/sync.py                                  248     12    95%
--------------------------------------------------------------------
TOTAL                                              424     35    92%

Required test coverage of 80% reached. Total coverage: 91.75%

```